### PR TITLE
improved portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 letslambda.yml
 .env
 src
+*.sw?
+*.pyc
+run.py

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ The configuration file is based on YAML. It should be easy to understand by revi
 `domains`: a list of domain information.
 
  - `name`: this is used to configure endpoints, DNS, and CN for the certification
+ - `r53_zone`: the route53 hosted zone name
  - `countryName`: is used for countryName in the CSR
- - `reuse_key`: will try to reuse the same private key to generate the CSR. This is very useful if you ever want to use Public Key pinning in your mobile app and yet, want to renew your certificates every x months.
+ - `elb`: name of your Elastic Load Balancer name
+ - `elb_region` the region is which your elb has been deployed in
+ - `reuse_key`: will try to reuse the same private key to generate the CSR. This is very useful if you ever want to use Public Key pinning in your mobile app and yet, want to renew your certificates every x months
 
 ## Installation ##
 

--- a/letslambda.example.yml
+++ b/letslambda.example.yml
@@ -5,4 +5,5 @@ domains:
   - name: example.com
     countryName: FR
     elb: ELB-1371YCZNGB8L2
+    elb_region: eu-west-1
     reuse_key: true

--- a/letslambda.example.yml
+++ b/letslambda.example.yml
@@ -3,6 +3,7 @@ info:
   - mailto:myemail@example.com
 domains:
   - name: example.com
+    r53_zone: example.com
     countryName: FR
     elb: ELB-1371YCZNGB8L2
     elb_region: eu-west-1

--- a/letslambda.json
+++ b/letslambda.json
@@ -1,12 +1,16 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Description" : "A template for letslambda - 0.1",
-    "Parameters": {
+    "Parameters": [{
         "Bucket": {
             "Description": "S3 Bucket name (not arn)",
             "Type": "String"
-        }
-    },
+        },
+	"Region": {
+            "Description": "Region short code name where the S3 bucket is located (ie: eu-west-1)",
+            "Type": "String"
+	}
+    }],
     "Resources" : {
         "LetsLambdaManagedPolicy": {
             "Type": "AWS::IAM::ManagedPolicy",
@@ -94,7 +98,7 @@
                 "Targets" : [ {
                     "Arn": {"Fn::GetAtt": ["LetsLambdaFunction", "Arn"]},
                     "Id": "LetsLambdaTarget",
-                    "Input": {"Fn::Join": ["", ["{\"bucket\": \"", {"Ref": "Bucket"}, "\"}"]]}
+                    "Input": {"Fn::Join": ["", ["{\"bucket\": \"", {"Ref": "Bucket"}, ", \"region\": \"", {"Ref": "Region"}, "\"}"]]}
                 } ]
             }
         }

--- a/letslambda.json
+++ b/letslambda.json
@@ -1,7 +1,7 @@
 {
     "AWSTemplateFormatVersion" : "2010-09-09",
     "Description" : "A template for letslambda - 0.1",
-    "Parameters": [{
+    "Parameters": {
         "Bucket": {
             "Description": "S3 Bucket name (not arn)",
             "Type": "String"
@@ -10,7 +10,7 @@
             "Description": "Region short code name where the S3 bucket is located (ie: eu-west-1)",
             "Type": "String"
 	}
-    }],
+    },
     "Resources" : {
         "LetsLambdaManagedPolicy": {
             "Type": "AWS::IAM::ManagedPolicy",

--- a/letslambda.py
+++ b/letslambda.py
@@ -21,6 +21,10 @@ from OpenSSL import crypto
 from datetime import datetime
 from boto.ec2 import elb
 from acme.jose.util import ComparableX509
+import os
+
+# this is the AWS region in which the function runs in
+exec_region = os.environ['AWS_DEFAULT_REGION']
 
 LOG = logging.getLogger("letslambda")
 LOG.setLevel(logging.DEBUG)
@@ -139,7 +143,7 @@ def answer_dns_challenge(client, domain, challenge):
 
     # Let's update the DNS on our R53 account
     top_level = ".".join(domain['name'].split(".")[-2:])
-    r53 = route53.connect_to_region("eu-west-1")
+    r53 = route53.connect_to_region(exec_region)
     zone = r53.get_zone(top_level)
     if zone == None:
         LOG.error("Cannot find R53 zone {}, are you controling it ?".format(top_level))
@@ -219,7 +223,7 @@ def createIAMCertificate(domain, certificate, key):
     if chain.status_code == 200:
         chain_certificate = crypto.load_certificate(crypto.FILETYPE_ASN1, chain.content)
 
-    iam_connection = iam.connect_to_region("eu-west-1")
+    iam_connection = iam.connect_to_region(exec_region)
     res = iam_connection.upload_server_cert(
         domain['name'] + "-" + datetime.utcnow().strftime("%Y-%m-%dT%H-%M"),
         crypto.dump_certificate(crypto.FILETYPE_PEM, certificate.body.wrapped).decode("ascii"),
@@ -232,7 +236,7 @@ def createIAMCertificate(domain, certificate, key):
 
 def updateELB(conf, iam_certificate):
     LOG.info("Updating ELB with new certificate")
-    elb_connection = elb.connect_to_region("eu-west-1")
+    elb_connection = elb.connect_to_region(conf['elb_region'])
     response = elb_connection.set_lb_listener_SSL_certificate(conf['elb'], 443, iam_certificate['upload_server_certificate_response']['upload_server_certificate_result']['server_certificate_metadata']['arn'])
     return response
 

--- a/letslambda.py
+++ b/letslambda.py
@@ -231,9 +231,10 @@ def updateELB(conf, iam_certificate):
 
 def lambda_handler(event, context):
     bucket = event['bucket']
+    region = event['region']
 
-    LOG.info("Retrieving configuration file from bucket : {}".format(bucket))
-    connection = s3.connect_to_region("eu-west-1", calling_format=OrdinaryCallingFormat())
+    LOG.info("Retrieving configuration file from bucket : {0} {1} ".format(bucket, region))
+    connection = s3.connect_to_region(region, calling_format=OrdinaryCallingFormat())
     try:
         bucket = connection.get_bucket(bucket);
     except S3ResponseError as e:

--- a/letslambda.py
+++ b/letslambda.py
@@ -251,7 +251,7 @@ def lambda_handler(event, context):
 
     conf = load_config(bucket)
     if conf == None:
-        LOG.error("Cannot file 'letslambda.yml' in S3 bucket '{0}".format(bucket))
+        LOG.error("Cannot find file 'letslambda.yml' in S3 bucket '{0}".format(bucket))
         exit(1)
 
     key = loadAccountKey(bucket, conf)

--- a/letslambda.py
+++ b/letslambda.py
@@ -142,11 +142,10 @@ def answer_dns_challenge(client, domain, challenge):
     dns_response = base64.urlsafe_b64encode(hashlib.sha256(authorization.encode()).digest()).decode("ascii").replace("=", "")
 
     # Let's update the DNS on our R53 account
-    top_level = ".".join(domain['name'].split(".")[-2:])
     r53 = route53.connect_to_region(exec_region)
-    zone = r53.get_zone(top_level)
+    zone = r53.get_zone(domain['r53_zone'])
     if zone == None:
-        LOG.error("Cannot find R53 zone {}, are you controling it ?".format(top_level))
+        LOG.error("Cannot find R53 zone {}, are you controling it ?".format(domain['r53_zone']))
         exit(1)
 
     acme_domain = "_acme-challenge.{}".format(domain['name'])


### PR DESCRIPTION
Hi,
- letslambda detects in which AWS region is runs from and connects to matching API endpoints
- letslambda gracefully reports if `letslambda.yml` is missing
- new input parameter so user can specify which aws region the s3 bucket is located
